### PR TITLE
Update Android Gradle Plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:7.1.2")
+        classpath("com.android.tools.build:gradle:7.3.0")
         classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.4.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0")
     }


### PR DESCRIPTION
Copy of https://github.com/apollographql/apollo-kotlin-tutorial/pull/29

Older versions of the plugin are not rebuilding on app restart. Instead, it requires a full clean rebuild

https://stackoverflow.com/questions/73796334/android-studio-failed-to-initialize-editor-dolphin-2021-3-1