### PR TITLE
Compose / Paging extensions explorations

### DIFF
--- a/compose/final/app/build.gradle.kts
+++ b/compose/final/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
-    id("com.apollographql.apollo3").version("3.7.5")
+    id("com.apollographql.apollo3").version("3.7.6-SNAPSHOT")
 }
 
 android {
@@ -64,6 +64,7 @@ dependencies {
     implementation("io.coil-kt:coil-compose:2.2.2")
 
     implementation("com.apollographql.apollo3:apollo-runtime")
+    implementation("com.apollographql.apollo3:apollo-compose-paging-support")
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/compose/final/app/src/main/graphql/LaunchList.graphql
+++ b/compose/final/app/src/main/graphql/LaunchList.graphql
@@ -1,5 +1,5 @@
-query LaunchList($cursor: String) {
-    launches(after: $cursor) {
+query LaunchList($cursor: String, $pageSize: Int) {
+    launches(after: $cursor, pageSize: $pageSize) {
         cursor
         launches {
             id

--- a/compose/final/app/src/main/java/com/example/rocketreserver/LaunchList.kt
+++ b/compose/final/app/src/main/java/com/example/rocketreserver/LaunchList.kt
@@ -4,48 +4,75 @@ package com.example.rocketreserver
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.paging.LoadState
+import androidx.paging.PagingConfig
+import androidx.paging.compose.items
 import coil.compose.AsyncImage
-import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.Optional
+import com.apollographql.apollo3.compose.paging.rememberAndCollectPager
+import com.apollographql.apollo3.exception.ApolloException
 
+@OptIn(ApolloExperimental::class)
 @Composable
 fun LaunchList(onLaunchClick: (launchId: String) -> Unit) {
-    var cursor: String? by remember { mutableStateOf(null) }
-    var response: ApolloResponse<LaunchListQuery.Data>? by remember { mutableStateOf(null) }
-    var launchList by remember { mutableStateOf(emptyList<LaunchListQuery.Launch>()) }
-    LaunchedEffect(cursor) {
-        response = apolloClient.query(LaunchListQuery(Optional.present(cursor))).execute()
-        launchList = launchList + response?.data?.launches?.launches?.filterNotNull().orEmpty()
-    }
+    val lazyPagingItems = rememberAndCollectPager<LaunchListQuery.Data, LaunchListQuery.Launch>(
+        config = PagingConfig(pageSize = 10),
+        appendCall = { response, loadSize ->
+            if (response?.data?.launches?.hasMore == false) {
+                // No more pages
+                null
+            } else {
+                apolloClient.query(
+                    LaunchListQuery(
+                        cursor = Optional.present(response?.data?.launches?.cursor),
+                        pageSize = Optional.present(loadSize)
+                    )
+                )
+            }
+        },
+        getItems = { response ->
+            if (response.hasErrors()) {
+                Result.failure(ApolloException(response.errors!![0].message))
+            } else {
+                Result.success(response.data!!.launches.launches.filterNotNull())
+            }
+        },
+    )
+    if (lazyPagingItems.loadState.refresh is LoadState.Loading) {
+        Loading()
+    } else {
+        LazyColumn {
+            items(lazyPagingItems) { launch ->
+                LaunchItem(launch = launch!!, onClick = onLaunchClick)
+            }
+            item {
+                when (val append = lazyPagingItems.loadState.append) {
+                    is LoadState.Error -> {
+                        ErrorItem(text = "Error: ${append.error.message}", onClick = { lazyPagingItems.retry() })
+                    }
 
-    LazyColumn {
-        items(launchList) { launch ->
-            LaunchItem(launch = launch, onClick = onLaunchClick)
-        }
+                    LoadState.Loading -> {
+                        LoadingItem()
+                    }
 
-        item {
-            if (response?.data?.launches?.hasMore == true) {
-                LoadingItem()
-                cursor = response?.data?.launches?.cursor
+                    else -> {}
+                }
             }
         }
     }
@@ -72,6 +99,27 @@ private fun LaunchItem(launch: LaunchListQuery.Launch, onClick: (launchId: Strin
                 error = painterResource(R.drawable.ic_placeholder),
                 contentDescription = "Mission patch"
             )
+        }
+    )
+}
+
+@Composable
+private fun Loading() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun ErrorItem(text: String, onClick: () -> Unit) {
+    ListItem(
+        headlineText = {
+            Text(text = text)
+        },
+        trailingContent = {
+            Button(onClick = onClick) {
+                Text(text = "Retry")
+            }
         }
     )
 }

--- a/compose/final/settings.gradle.kts
+++ b/compose/final/settings.gradle.kts
@@ -5,6 +5,10 @@ if (javaVersion.substringBefore(".").toInt() < 11) {
 
 pluginManagement {
     repositories {
+        mavenLocal()
+        maven {
+            url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        }
         google()
         mavenCentral()
         gradlePluginPortal()
@@ -14,6 +18,10 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
+        mavenLocal()
+        maven {
+            url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        }
         google()
         mavenCentral()
     }

--- a/v4/final/app/build.gradle.kts
+++ b/v4/final/app/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation("io.coil-kt:coil-compose:2.2.2")
 
     implementation("com.apollographql.apollo3:apollo-runtime")
+    implementation("com.apollographql.apollo3:apollo-compose-paging-support")
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/v4/final/app/src/main/graphql/LaunchList.graphql
+++ b/v4/final/app/src/main/graphql/LaunchList.graphql
@@ -1,5 +1,5 @@
-query LaunchList($cursor: String) {
-    launches(after: $cursor) {
+query LaunchList($cursor: String, $pageSize: Int) {
+    launches(after: $cursor, pageSize: $pageSize) {
         cursor
         launches {
             id

--- a/v4/final/app/src/main/java/com/example/rocketreserver/LaunchDetails.kt
+++ b/v4/final/app/src/main/java/com/example/rocketreserver/LaunchDetails.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -27,45 +26,20 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
-import com.apollographql.apollo3.api.Error
-import com.apollographql.apollo3.exception.ApolloException
-import com.example.rocketreserver.LaunchDetailsState.ApplicationError
-import com.example.rocketreserver.LaunchDetailsState.Loading
-import com.example.rocketreserver.LaunchDetailsState.ProtocolError
-import com.example.rocketreserver.LaunchDetailsState.Success
+import com.apollographql.apollo3.annotations.ApolloExperimental
+import com.apollographql.apollo3.compose.toState
 import kotlinx.coroutines.launch
 
-private sealed interface LaunchDetailsState {
-    object Loading : LaunchDetailsState
-    data class ProtocolError(val exception: ApolloException) : LaunchDetailsState
-    data class ApplicationError(val errors: List<Error>) : LaunchDetailsState
-    data class Success(val data: LaunchDetailsQuery.Data) : LaunchDetailsState
-}
-
+@OptIn(ApolloExperimental::class)
 @Composable
 fun LaunchDetails(launchId: String, navigateToLogin: () -> Unit) {
-    var state by remember { mutableStateOf<LaunchDetailsState>(Loading) }
-    LaunchedEffect(Unit) {
-        val response = apolloClient.query(LaunchDetailsQuery(launchId)).execute()
-        state = when {
-            response.exception != null -> {
-                ProtocolError(response.exception!!)
-            }
-
-            response.hasErrors() -> {
-                ApplicationError(response.errors!!)
-            }
-
-            else -> {
-                Success(response.data!!)
-            }
-        }
-    }
-    when (val s = state) {
-        Loading -> Loading()
-        is ProtocolError -> ErrorMessage("Oh no... A protocol error happened: ${s.exception.message}")
-        is ApplicationError -> ErrorMessage(s.errors[0].message)
-        is Success -> LaunchDetails(s.data, navigateToLogin)
+    val response by apolloClient.query(LaunchDetailsQuery(launchId)).toState()
+    val r = response
+    when {
+        r == null -> Loading()
+        r.exception != null -> ErrorMessage("Oh no... A protocol error happened: ${r.exception!!.message}")
+        r.hasErrors() -> ErrorMessage(r.errors!![0].message)
+        else -> LaunchDetails(r.data!!, navigateToLogin)
     }
 }
 

--- a/v4/final/app/src/main/java/com/example/rocketreserver/LaunchList.kt
+++ b/v4/final/app/src/main/java/com/example/rocketreserver/LaunchList.kt
@@ -4,48 +4,75 @@ package com.example.rocketreserver
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.paging.LoadState
+import androidx.paging.PagingConfig
+import androidx.paging.compose.items
 import coil.compose.AsyncImage
-import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.Optional
+import com.apollographql.apollo3.compose.paging.rememberAndCollectPager
+import com.apollographql.apollo3.exception.ApolloException
 
+@OptIn(ApolloExperimental::class)
 @Composable
 fun LaunchList(onLaunchClick: (launchId: String) -> Unit) {
-    var cursor: String? by remember { mutableStateOf(null) }
-    var response: ApolloResponse<LaunchListQuery.Data>? by remember { mutableStateOf(null) }
-    var launchList by remember { mutableStateOf(emptyList<LaunchListQuery.Launch>()) }
-    LaunchedEffect(cursor) {
-        response = apolloClient.query(LaunchListQuery(Optional.present(cursor))).execute()
-        launchList = launchList + response?.data?.launches?.launches?.filterNotNull().orEmpty()
-    }
+    val lazyPagingItems = rememberAndCollectPager<LaunchListQuery.Data, LaunchListQuery.Launch>(
+        config = PagingConfig(pageSize = 10),
+        appendCall = { response, loadSize ->
+            if (response?.data?.launches?.hasMore == false) {
+                // No more pages
+                null
+            } else {
+                apolloClient.query(
+                    LaunchListQuery(
+                        cursor = Optional.present(response?.data?.launches?.cursor),
+                        pageSize = Optional.present(loadSize)
+                    )
+                )
+            }
+        },
+        getItems = { response ->
+            if (response.hasErrors()) {
+                Result.failure(ApolloException(response.errors!![0].message))
+            } else {
+                Result.success(response.data!!.launches.launches.filterNotNull())
+            }
+        },
+    )
+    if (lazyPagingItems.loadState.refresh is LoadState.Loading) {
+        Loading()
+    } else {
+        LazyColumn {
+            items(lazyPagingItems) { launch ->
+                LaunchItem(launch = launch!!, onClick = onLaunchClick)
+            }
+            item {
+                when (val append = lazyPagingItems.loadState.append) {
+                    is LoadState.Error -> {
+                        ErrorItem(text = "Error: ${append.error.message}", onClick = { lazyPagingItems.retry() })
+                    }
 
-    LazyColumn {
-        items(launchList) { launch ->
-            LaunchItem(launch = launch, onClick = onLaunchClick)
-        }
+                    LoadState.Loading -> {
+                        LoadingItem()
+                    }
 
-        item {
-            if (response?.data?.launches?.hasMore == true) {
-                LoadingItem()
-                cursor = response?.data?.launches?.cursor
+                    else -> {}
+                }
             }
         }
     }
@@ -72,6 +99,27 @@ private fun LaunchItem(launch: LaunchListQuery.Launch, onClick: (launchId: Strin
                 error = painterResource(R.drawable.ic_placeholder),
                 contentDescription = "Mission patch"
             )
+        }
+    )
+}
+
+@Composable
+private fun Loading() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun ErrorItem(text: String, onClick: () -> Unit) {
+    ListItem(
+        headlineText = {
+            Text(text = text)
+        },
+        trailingContent = {
+            Button(onClick = onClick) {
+                Text(text = "Retry")
+            }
         }
     )
 }

--- a/v4/final/settings.gradle.kts
+++ b/v4/final/settings.gradle.kts
@@ -5,6 +5,7 @@ if (javaVersion.substringBefore(".").toInt() < 11) {
 
 pluginManagement {
     repositories {
+        mavenLocal()
         maven {
             url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
         }
@@ -17,6 +18,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
+        mavenLocal()
         maven {
             url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
         }


### PR DESCRIPTION
For now:

- `toState()`  /  `watchAsState()` Simplifies observing a call
- `rememberAndCollectPager()`: On top of Jetpack Paging